### PR TITLE
Apps not working in 18.10

### DIFF
--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -2194,7 +2194,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.hipchat&hl=en",
             "url-ios": "https://itunes.apple.com/us/app/hipchat-group-chat-video-file/id418168984?mt=8",
             "arch": "amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2588,7 +2588,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.spideroak.android",
             "url-ios": "https://itunes.apple.com/gb/app/spideroak/id360584371",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2623,7 +2623,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.Slack&hl=en",
             "url-ios": "https://itunes.apple.com/gb/app/slack/id803453959?mt=12",
             "arch": "amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2849,7 +2849,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2913,7 +2913,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.wire",
             "url-ios": "https://itunes.apple.com/gb/app/wire-private-messenger/id930944768",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3445,7 +3445,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3659,7 +3659,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -4106,7 +4106,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.android.music",
             "url-ios": "https://itunes.apple.com/gb/app/google-play-music/id691797987",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -4528,7 +4528,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.spotify.music",
             "url-ios": "https://itunes.apple.com/gb/app/spotify-music/id324684580",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -4793,7 +4793,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp",
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,cosmic",
+            "releases": "xenial,bionic",
             "pre-install": {
                 "all": {
                     "method": "ppa",


### PR DESCRIPTION
This is the list:
Hipchat4
Slack-desktop
Spideroakone
Vivaldi
Wire-desktop
Atom
Microsoft visual code
Google play music desktop player
Spotify
KDEconnect-indicator