### PR TITLE
Spotify has new GPG key link

### DIFF
--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -4606,7 +4606,7 @@
                 "all": {
                     "method": "manual",
                     "source-file": "spotify",
-                    "apt-key-url": "https://download.spotify.com/debian/pubkey.gpg",
+                    "apt-key-url": "https://download.spotify.com/debian/pubkey_0D811D58.gpg",
                     "apt-sources": [
                         "deb http://repository.spotify.com stable non-free"
                     ]


### PR DESCRIPTION
According to https://www.spotify.com/us/download/linux/ the link to GPG key is changed to https://download.spotify.com/debian/pubkey_0D811D58.gpg .