### PR TITLE
Added "remove-packages" for "ubuntu-mate-welcome" 

### DIFF
--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -5401,6 +5401,7 @@
             "img": "system",
             "main-package": "ubuntu-mate-welcome",
             "install-packages": "ubuntu-mate-welcome",
+            "remove-packages": "ubuntu-mate-welcome",
             "launch-command": "ubuntu-mate-welcome",
             "description": [
                 ""


### PR DESCRIPTION
This is to avoid a warning while converting the old index to the new format.