### PR TITLE
update spotify GPG key

### DIFF
--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -4760,7 +4760,7 @@
                 "all": {
                     "method": "manual",
                     "source-file": "spotify",
-                    "apt-key-url": "https://download.spotify.com/debian/pubkey_0D811D58.gpg",
+                    "apt-key-url": "https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg",
                     "apt-sources": [
                         "deb http://repository.spotify.com stable non-free"
                     ]


### PR DESCRIPTION
According to https://www.spotify.com/download/linux/ new GPG key url is the following:

`https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg`

So our 