### PR TITLE
application index update and cleanup, add upcoming jammy (22.04 LTS)

### DIFF
--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -183,7 +183,7 @@
             "name": "Etcher",
             "img": "etcher",
             "main-package": "balena-etcher-electron",
-            "launch-command": "balena-etcher-electron",
+            "launch-command": "/opt/balenaEtcher/balena-etcher-electron",
             "install-packages": "balena-etcher-electron",
             "remove-packages": "balena-etcher-electron",
             "description": [
@@ -2552,13 +2552,13 @@
             "img": "remmina",
             "main-package": "remmina",
             "launch-command": "remmina",
-            "install-packages": "remmina,remmina-plugin-rdp,remmina-plugin-vnc,remmina-plugin-nx,remmina-plugin-xdmcp",
-            "remove-packages": "remmina,remmina-plugin-rdp,remmina-plugin-vnc,remmina-plugin-nx,remmina-plugin-xdmcp",
+            "install-packages": "remmina,remmina-plugin-rdp,remmina-plugin-vnc",
+            "remove-packages": "remmina,remmina-plugin-rdp,remmina-plugin-vnc",
             "description": [
                 "A remote desktop connection client able",
                 "to display and control a remote desktop session. It supports",
                 "multiple network protocols in an integrated and consistent",
-                "user interface. Currently RDP, VNC, NX, XDMCP and SSH",
+                "user interface. Currently RDP, VNC and SSH",
                 "protocols are supported."
             ],
             "alternate-to": "Microsoft&reg; Remote Desktop",
@@ -2691,7 +2691,7 @@
             "name": "Slack",
             "img": "slack",
             "main-package": "slack-desktop",
-            "launch-command": "slack-desktop",
+            "launch-command": "slack",
             "install-packages": "slack-desktop",
             "remove-packages": "slack-desktop",
             "description": [
@@ -2982,7 +2982,7 @@
             "name": "Wire",
             "img": "wire-desktop",
             "main-package": "wire-desktop",
-            "launch-command": "/opt/wire-desktop/wire-desktop",
+            "launch-command": "/opt/Wire/wire-desktop",
             "install-packages": "wire-desktop",
             "remove-packages": "wire-desktop",
             "description": [
@@ -3012,10 +3012,10 @@
         "wireshark": {
             "name": "Wireshark",
             "img": "wireshark",
-            "main-package": "wireshark-gtk",
-            "launch-command": "wireshark-gtk",
-            "install-packages": "wireshark-gtk",
-            "remove-packages": "wireshark-gtk,wireshark-common",
+            "main-package": "wireshark-qt",
+            "launch-command": "wireshark",
+            "install-packages": "wireshark-qt",
+            "remove-packages": "wireshark-qt,wireshark-common",
             "description": [
                 "The world&#8217;s foremost network protocol analyzer. It",
                 "lets you see what&#8217;s happening on your network at a",
@@ -3923,7 +3923,7 @@
             "name": "Ardour",
             "img": "ardour",
             "main-package": "ardour",
-            "launch-command": "ardour4",
+            "launch-command": "gio launch /usr/share/applications/ardour.desktop",
             "install-packages": "ardour",
             "remove-packages": "ardour",
             "description": [
@@ -5396,8 +5396,8 @@
             "img": "synaptic",
             "main-package": "synaptic",
             "launch-command": "pkexec synaptic",
-            "install-packages": "synaptic",
-            "remove-packages": "synaptic",
+            "install-packages": "synaptic,apt-xapian-index",
+            "remove-packages": "synaptic,apt-xapian-index",
             "description": [
                 "A graphical package management program",
                 "for <code>apt</code>. It provides the same features as the",

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -2477,7 +2477,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.owncloud.android",
             "url-ios": "https://itunes.apple.com/gb/app/owncloud/id543672169",
             "arch": "i386,amd64",
-            "releases": "bionic,focal,jammy",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -227,7 +227,7 @@
             "url-info": "https://www.keepassxc.org/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -264,7 +264,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,focal",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -385,7 +385,7 @@
             "url-info": "https://veracrypt.codeplex.com/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -621,7 +621,7 @@
             "url-info": "http://play0ad.com/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -711,7 +711,7 @@
             "url-info": "http://www.flightgear.org/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64,arm64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -833,7 +833,7 @@
             "url-info": "http://www.hedgewars.org",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -859,7 +859,7 @@
             "url-info": "http://lutris.net",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -896,7 +896,7 @@
             "url-info": "https://minecraft.net",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -1021,7 +1021,7 @@
             "url-info": "http://www.alientrap.org/games/nexuiz",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -1145,7 +1145,7 @@
             "url-info": "http://libretro.com",
             "url-android": "https://play.google.com/store/apps/details?id=com.retroarch",
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -1239,12 +1239,20 @@
             "url-ios": null,
             "arch": "armhf",
             "session": "pi",
-            "releases": "bionic",
+            "releases": "bionic,focal",
             "pre-install": {
                 "all": {
+                    "method": "skip"
+                },
+                "bionic": {
                     "method": "ppa",
                     "enable-ppa": "ppa:ubuntu-pi-flavour-makers/ppa",
                     "source-file": "ubuntu-pi-flavour-makers-ubuntu-ppa-CODENAME"
+                },
+                "focal": {
+                    "method": "ppa",
+                    "enable-ppa": "ppa:ubuntu-pi-flavour-makers/steamlink",
+                    "source-file": "ubuntu-pi-flavour-makers-ubuntu-steamlink-CODENAME"
                 }
             },
             "working": true
@@ -1340,7 +1348,7 @@
             "url-info": "https://wz2100.net/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -1372,7 +1380,7 @@
             "url-info": "http://wesnoth.org/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -1409,7 +1417,7 @@
             "url-info": "https://www.blender.org/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -1710,8 +1718,8 @@
             "url-info": "http://qtpfsgui.sourceforge.net/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
-            "releases": "bionic,focal,impish,jammy",
+            "arch": "i386,amd64,armhf,arm64",
+            "releases": "bionic,focal,impish",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1888,7 +1896,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.brave.browser",
             "url-ios": "https://itunes.apple.com/us/app/brave-web-browser-fast-with-built-in-adblock/id1052879175",
             "arch": "amd64",
-            "releases": "bionic,focal,focal,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2096,7 +2104,7 @@
             "url-info": "https://gobby.github.io",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -2440,7 +2448,7 @@
             "url-info": "https://nextcloud.com/",
             "url-android": "https://play.google.com/store/apps/details?id=com.nextcloud.client",
             "url-ios": "https://itunes.apple.com/gb/app/nextcloud/id1125420102",
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -2604,7 +2612,7 @@
             "url-info": "http://sparkleshare.org/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -2704,7 +2712,7 @@
             "url-info": "https://syncthing.net/",
             "url-android": "https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid",
             "url-ios": null,
-            "arch": "i386,amd64,armhf",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -3300,7 +3308,7 @@
             "url-info": "https://www.libreoffice.org/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal",
             "pre-install": {
                 "all": {
@@ -4039,7 +4047,7 @@
             "url-info": "http://www.clementine-player.org/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -4284,7 +4292,7 @@
             "url-info": "https://handbrake.fr",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -4347,7 +4355,7 @@
             "url-info": "https://kodi.tv/",
             "url-android": "https://play.google.com/store/apps/details?id=org.xbmc.kodi",
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -4449,7 +4457,7 @@
             "url-info": "https://obsproject.com",
             "url-android": null,
             "url-ios": null,
-            "arch": "amd64",
+            "arch": "amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -4538,7 +4546,7 @@
             "url-info": "https://github.com/phw/peek",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "bionic": {
@@ -4631,7 +4639,7 @@
             "url-info": "http://www.maartenbaert.be/simplescreenrecorder/",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -5155,7 +5163,7 @@
             "url-info": "https://jellyfin.github.io/",
             "url-android": null,
             "url-ios": null,
-            "arch": "amd64,armhf",
+            "arch": "amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -5411,7 +5419,7 @@
             "url-info": "",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -5528,7 +5536,7 @@
             "url-info": "",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64,armhf",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
@@ -5693,7 +5701,7 @@
             "url-info": "http://www.videolan.org/developers/libdvdcss.html",
             "url-android": null,
             "url-ios": null,
-            "arch": "i386,amd64",
+            "arch": "i386,amd64,armhf,arm64",
             "releases": "bionic",
             "pre-install": {
                 "all": {
@@ -5720,7 +5728,7 @@
             "url-info": "http://www.videolan.org/developers/libdvdcss.html",
             "url-android": null,
             "url-ios": null,
-            "arch": "amd64",
+            "arch": "amd64,armhf,arm64",
             "releases": "focal",
             "pre-install": {
                 "all": {
@@ -5747,7 +5755,7 @@
             "url-info": "http://www.videolan.org/developers/libdvdcss.html",
             "url-android": null,
             "url-ios": null,
-            "arch": "amd64",
+            "arch": "amd64,armhf,arm64",
             "releases": "impish,jammy",
             "pre-install": {
                 "all": {

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -1953,7 +1953,7 @@
             "name": "Caja Dropbox",
             "img": "dropbox",
             "main-package": "caja-dropbox",
-            "launch-command": "caja-dropbox",
+            "launch-command": "caja-dropbox start",
             "install-packages": "caja-dropbox",
             "remove-packages": "caja-dropbox",
             "description": [

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -4929,7 +4929,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp",
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,focal,impish,jammy",
+            "releases": "bionic,focal",
             "pre-install": {
                 "all": {
                     "method": "ppa",

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -3870,7 +3870,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -3923,7 +3923,7 @@
             "name": "Ardour",
             "img": "ardour",
             "main-package": "ardour",
-            "launch-command": "gio launch /usr/share/applications/ardour.desktop",
+            "launch-command": "gtk-launch ardour.desktop",
             "install-packages": "ardour",
             "remove-packages": "ardour",
             "description": [

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -20,7 +20,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -54,7 +54,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -84,7 +84,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -116,7 +116,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -143,7 +143,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -171,7 +171,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -198,7 +198,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -233,7 +233,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -330,7 +330,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "bionic,disco,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,disco,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -362,7 +362,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -459,7 +459,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -489,7 +489,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -521,7 +521,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -563,7 +563,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -593,7 +593,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -627,7 +627,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -662,7 +662,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -692,7 +692,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -722,7 +722,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -750,7 +750,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -784,7 +784,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -809,7 +809,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -844,7 +844,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -871,7 +871,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -908,7 +908,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -975,7 +975,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1005,7 +1005,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1038,7 +1038,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1065,7 +1065,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1108,7 +1108,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1136,7 +1136,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1162,7 +1162,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.retroarch",
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -1230,7 +1230,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.valvesoftware.android.steam.community&hl=en",
             "url-ios": "https://itunes.apple.com/gb/app/steam-mobile/id495369748",
             "arch": "i386,amd64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "multiverse-repo"
@@ -1299,7 +1299,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1329,7 +1329,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1362,7 +1362,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1394,7 +1394,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1431,7 +1431,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1535,7 +1535,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1568,7 +1568,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1597,7 +1597,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                  "all": {
                     "method": "skip"
@@ -1632,7 +1632,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1660,7 +1660,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1696,7 +1696,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1732,7 +1732,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1762,7 +1762,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1791,7 +1791,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1824,7 +1824,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1851,7 +1851,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1909,7 +1909,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.brave.browser",
             "url-ios": "https://itunes.apple.com/us/app/brave-web-browser-fast-with-built-in-adblock/id1052879175",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -1941,7 +1941,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1968,7 +1968,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.dropbox.android",
             "url-ios": "https://itunes.apple.com/us/app/dropbox/id327630330",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1996,7 +1996,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,armhf,arm64",
-            "releases": "bionic,focal,hirsute,impish",
+            "releases": "bionic,focal,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2031,7 +2031,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2060,7 +2060,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.mozilla.firefox",
             "url-ios": "https://itunes.apple.com/us/app/firefox-web-browser/id989804926",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2088,7 +2088,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2118,7 +2118,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2146,7 +2146,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.android.chrome",
             "url-ios": "https://itunes.apple.com/gb/app/chrome-web-browser-by-google/id535886823",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2179,7 +2179,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.earth",
             "url-ios": "https://itunes.apple.com/gb/app/google-earth/id293622097",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2215,7 +2215,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.android.music",
             "url-ios": "https://itunes.apple.com/gb/app/google-play-music/id691797987",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2248,7 +2248,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2281,7 +2281,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.android.apps.docs",
             "url-ios": "https://itunes.apple.com/gb/app/google-drive-free-online-storage/id507874739",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2347,7 +2347,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2375,7 +2375,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.microsoft.emmx",
             "url-ios": "https://apps.apple.com/us/app/microsoft-edge-web-browser/id1288723196",
             "arch": "amd64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2414,7 +2414,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.morlunk.mumbleclient.free",
             "url-ios": "http://itunes.apple.com/us/app/mumble/id443472808",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -2447,7 +2447,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.opera.browser",
             "url-ios": "https://itunes.apple.com/gb/app/opera-mini-web-browser/id363729560",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2539,7 +2539,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2568,7 +2568,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2598,7 +2598,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.skype.raider",
             "url-ios": "https://itunes.apple.com/gb/app/skype-for-iphone/id304878510",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2642,7 +2642,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2673,7 +2673,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.spideroak.android",
             "url-ios": "https://itunes.apple.com/gb/app/spideroak/id360584371",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2708,7 +2708,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.Slack&hl=en",
             "url-ios": "https://itunes.apple.com/gb/app/slack/id803453959?mt=12",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2742,7 +2742,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid",
             "url-ios": null,
             "arch": "i386,amd64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2782,7 +2782,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.telegram.messenger",
             "url-ios": "https://itunes.apple.com/gb/app/telegram-messenger/id686449807",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2814,7 +2814,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2847,7 +2847,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2875,7 +2875,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2904,7 +2904,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2934,7 +2934,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2965,7 +2965,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2998,7 +2998,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.wire",
             "url-ios": "https://itunes.apple.com/gb/app/wire-private-messenger/id930944768",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3030,7 +3030,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3063,7 +3063,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3131,7 +3131,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3158,7 +3158,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3191,7 +3191,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3216,7 +3216,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -3248,7 +3248,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3283,7 +3283,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3314,7 +3314,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3372,7 +3372,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3400,7 +3400,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3432,7 +3432,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -3468,7 +3468,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3525,7 +3525,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3556,7 +3556,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan",
+            "releases": "xenial,bionic,eoan,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3590,7 +3590,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3622,7 +3622,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3650,7 +3650,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3680,7 +3680,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3708,7 +3708,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,i386",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3739,7 +3739,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,i386",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3775,7 +3775,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3877,7 +3877,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3946,7 +3946,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3976,7 +3976,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4033,7 +4033,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4060,7 +4060,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4250,7 +4250,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4280,7 +4280,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4309,7 +4309,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.android.music",
             "url-ios": "https://itunes.apple.com/gb/app/google-play-music/id691797987",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -4342,7 +4342,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4374,7 +4374,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4405,7 +4405,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.xbmc.kodi",
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4439,7 +4439,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,arm64,armhf",
-            "releases": "focal,groovy,hirsute,impish",
+            "releases": "focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4477,7 +4477,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -4544,7 +4544,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.pandora.android",
             "url-ios": "https://itunes.apple.com/en/app/pandora-radio/id284035177",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4573,7 +4573,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4603,7 +4603,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial,bionic": {
                     "method": "ppa",
@@ -4636,7 +4636,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4667,7 +4667,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4696,7 +4696,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -4729,7 +4729,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4755,7 +4755,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.spotify.music",
             "url-ios": "https://itunes.apple.com/gb/app/spotify-music/id324684580",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -4787,7 +4787,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.videolan.vlc",
             "url-ios": "https://itunes.apple.com/gb/app/vlc-for-mobile/id650377962",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4850,7 +4850,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4881,7 +4881,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4908,7 +4908,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4935,7 +4935,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4963,7 +4963,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4990,7 +4990,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp",
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5018,7 +5018,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5045,7 +5045,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5105,7 +5105,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5136,7 +5136,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -5169,7 +5169,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5198,7 +5198,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5230,7 +5230,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,armhf",
-            "releases": "xenial,bionic,disco",
+            "releases": "xenial,bionic,disco,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -5263,7 +5263,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5293,7 +5293,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.morlunk.mumbleclient.free",
             "url-ios": "http://itunes.apple.com/us/app/mumble/id443472808",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "xenial": {
                     "method": "ppa",
@@ -5328,7 +5328,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5356,7 +5356,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5383,7 +5383,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5414,7 +5414,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5441,7 +5441,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5468,7 +5468,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5491,7 +5491,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5516,7 +5516,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5539,7 +5539,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5562,7 +5562,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5585,7 +5585,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5608,7 +5608,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5631,7 +5631,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5654,7 +5654,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5677,7 +5677,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5700,7 +5700,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5723,7 +5723,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5746,7 +5746,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5850,7 +5850,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5873,7 +5873,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5896,7 +5896,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5921,7 +5921,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5946,7 +5946,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5971,7 +5971,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5996,7 +5996,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6021,7 +6021,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6046,7 +6046,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6071,7 +6071,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6096,7 +6096,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6121,7 +6121,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6146,7 +6146,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish",
+            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -3802,7 +3802,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "bionic",
+            "releases": "bionic,focal",
             "pre-install": {
                 "all": {
                     "method": "manual",

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -3778,12 +3778,12 @@
             "working": true
         },
         "pgadmin": {
-            "name": "pgAdmin 4",
+            "name": "pgAdmin 3",
             "img": "pgadmin3",
-            "main-package": "pgadmin4",
-            "launch-command": "pgadmin4",
-            "install-packages": "pgadmin4",
-            "remove-packages": "pgadmin4",
+            "main-package": "pgadmin3",
+            "launch-command": "pgadmin3",
+            "install-packages": "pgadmin3",
+            "remove-packages": "pgadmin3",
             "description": [
                 "A database design and management",
                 "application for use with PostgreSQL. pgAdmin is designed",

--- a/data/js/applications.json
+++ b/data/js/applications.json
@@ -20,13 +20,8 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:caffeine-developers/ppa",
-                    "source-file": "caffeine-developers-ubuntu-ppa-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -54,7 +49,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -84,7 +79,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -116,7 +111,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -143,7 +138,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -171,7 +166,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -198,7 +193,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -233,7 +228,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -269,7 +264,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy",
+            "releases": "bionic,focal",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -301,7 +296,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.subsurfacedivelog.mobile",
             "url-ios": "https://itunes.apple.com/gb/app/subsurface/id907870605?mt=8",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -330,7 +325,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "bionic,disco,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -362,7 +357,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -391,7 +386,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -408,8 +403,8 @@
             "img": "gcompris",
             "main-package": "gcompris",
             "launch-command": "gcompris",
-            "install-packages": "gcompris,gcompris-data,gcompris-sound-af,gcompris-sound-ar,gcompris-sound-ast,gcompris-sound-bg,gcompris-sound-br,gcompris-sound-cs,gcompris-sound-da,gcompris-sound-de,gcompris-sound-el,gcompris-sound-en,gcompris-sound-eo,gcompris-sound-es,gcompris-sound-eu,gcompris-sound-fi,gcompris-sound-fr,gcompris-sound-gd,gcompris-sound-he,gcompris-sound-hi,gcompris-sound-hu,gcompris-sound-id,gcompris-sound-it,gcompris-sound-kn,gcompris-sound-lt,gcompris-sound-mr,gcompris-sound-nb,gcompris-sound-nl,gcompris-sound-nn,gcompris-sound-pa,gcompris-sound-pt,gcompris-sound-ptbr,gcompris-sound-ru,gcompris-sound-sk,gcompris-sound-sl,gcompris-sound-so,gcompris-sound-sr,gcompris-sound-sv,gcompris-sound-th,gcompris-sound-tr,gcompris-sound-ur,gcompris-sound-zhcn",
-            "remove-packages": "gcompris,gcompris-data,gcompris-sound-af,gcompris-sound-ar,gcompris-sound-ast,gcompris-sound-bg,gcompris-sound-br,gcompris-sound-cs,gcompris-sound-da,gcompris-sound-de,gcompris-sound-el,gcompris-sound-en,gcompris-sound-eo,gcompris-sound-es,gcompris-sound-eu,gcompris-sound-fi,gcompris-sound-fr,gcompris-sound-gd,gcompris-sound-he,gcompris-sound-hi,gcompris-sound-hu,gcompris-sound-id,gcompris-sound-it,gcompris-sound-kn,gcompris-sound-lt,gcompris-sound-mr,gcompris-sound-nb,gcompris-sound-nl,gcompris-sound-nn,gcompris-sound-pa,gcompris-sound-pt,gcompris-sound-ptbr,gcompris-sound-ru,gcompris-sound-sk,gcompris-sound-sl,gcompris-sound-so,gcompris-sound-sr,gcompris-sound-sv,gcompris-sound-th,gcompris-sound-tr,gcompris-sound-ur,gcompris-sound-zhcn",
+            "install-packages": "gcompris",
+            "remove-packages": "gcompris",
             "description": [
                 "A high quality educational software",
                 "suite comprising of numerous activities for children aged 2",
@@ -427,7 +422,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial",
+            "releases": "bionic,focal,impish",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -459,7 +454,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -489,7 +484,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -521,7 +516,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -563,7 +558,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -593,7 +588,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -627,13 +622,8 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:wfg/0ad",
-                    "source-file": "wfg-ubuntu-0ad-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -662,7 +652,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -692,7 +682,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -722,7 +712,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -750,7 +740,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -784,7 +774,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -809,7 +799,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -844,14 +834,13 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
                 }
             },
-            "working": true,
-            "notes": "no packages for armhf on xenial"
+            "working": true
         },
         "lutris": {
             "name": "Lutris",
@@ -871,7 +860,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -908,7 +897,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -938,13 +927,8 @@
             "url-ios": null,
             "arch": "armhf",
             "session": "pi",
-            "releases": "xenial,bionic",
+            "releases": "bionic,focal",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:flexiondotorg/minecraft",
-                    "source-file": "flexiondotorg-ubuntu-minecraft-CODENAME"
-                },
                 "all": {
                     "method": "ppa",
                     "enable-ppa": "ppa:ubuntu-pi-flavour-makers/ppa",
@@ -975,7 +959,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1005,7 +989,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1038,7 +1022,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1065,12 +1049,12 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
                 },
-                "xenial,bionic": {
+                "bionic": {
                     "method": "manual",
                     "apt-key-url": "http://deb.playonlinux.com/public.gpg",
                     "source-file": "playonlinux",
@@ -1108,7 +1092,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1136,7 +1120,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1162,13 +1146,8 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.retroarch",
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:libretro/stable",
-                    "source-file": "libretro-ubuntu-stable-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -1198,7 +1177,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.valvesoftware.android.steam.community&hl=en",
             "url-ios": "https://itunes.apple.com/gb/app/steam-mobile/id495369748",
             "arch": "i386,amd64",
-            "releases": "xenial",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "multiverse-repo"
@@ -1230,7 +1209,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.valvesoftware.android.steam.community&hl=en",
             "url-ios": "https://itunes.apple.com/gb/app/steam-mobile/id495369748",
             "arch": "i386,amd64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "multiverse-repo"
@@ -1299,7 +1278,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1329,7 +1308,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1362,7 +1341,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1394,7 +1373,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1431,7 +1410,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1442,10 +1421,10 @@
         "dia": {
             "name": "Dia",
             "img": "dia",
-            "main-package": "dia-gnome",
-            "launch-command": "dia-gnome",
-            "install-packages": "dia-gnome",
-            "remove-packages": "dia-gnome",
+            "main-package": "dia",
+            "launch-command": "dia",
+            "install-packages": "dia",
+            "remove-packages": "dia",
             "description": [
                 "An editor for diagrams, graphs, charts etc.",
                 "There is support for UML static structure diagrams (class",
@@ -1460,7 +1439,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1493,7 +1472,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "eoan",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1535,7 +1514,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1568,7 +1547,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1597,7 +1576,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                  "all": {
                     "method": "skip"
@@ -1632,7 +1611,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1660,7 +1639,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1696,7 +1675,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1732,7 +1711,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1762,7 +1741,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1791,7 +1770,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1824,7 +1803,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1851,7 +1830,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1881,7 +1860,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal",
+            "releases": "bionic,focal",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1909,7 +1888,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.brave.browser",
             "url-ios": "https://itunes.apple.com/us/app/brave-web-browser-fast-with-built-in-adblock/id1052879175",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -1941,7 +1920,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1968,7 +1947,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.dropbox.android",
             "url-ios": "https://itunes.apple.com/us/app/dropbox/id327630330",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -1996,7 +1975,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,armhf,arm64",
-            "releases": "bionic,focal,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2031,7 +2010,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2060,7 +2039,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.mozilla.firefox",
             "url-ios": "https://itunes.apple.com/us/app/firefox-web-browser/id989804926",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2088,7 +2067,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2118,7 +2097,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2146,7 +2125,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.android.chrome",
             "url-ios": "https://itunes.apple.com/gb/app/chrome-web-browser-by-google/id535886823",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2179,7 +2158,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.earth",
             "url-ios": "https://itunes.apple.com/gb/app/google-earth/id293622097",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2215,7 +2194,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.android.music",
             "url-ios": "https://itunes.apple.com/gb/app/google-play-music/id691797987",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2248,7 +2227,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2281,7 +2260,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.android.apps.docs",
             "url-ios": "https://itunes.apple.com/gb/app/google-drive-free-online-storage/id507874739",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2294,7 +2273,7 @@
                         "deb http://apt.insync.io/ubuntu CODENAME non-free contrib"
                     ]
                 },
-                "groovy": {
+                "jammy": {
                     "method": "manual",
                     "source-file": "insync",
                     "apt-key-server": [
@@ -2302,18 +2281,7 @@
                         "ACCAF35C"
                     ],
                     "apt-sources": [
-                        "deb http://apt.insync.io/ubuntu focal non-free contrib"
-                    ]
-                },
-                "hirsute": {
-                    "method": "manual",
-                    "source-file": "insync",
-                    "apt-key-server": [
-                        "keyserver.ubuntu.com",
-                        "ACCAF35C"
-                    ],
-                    "apt-sources": [
-                        "deb http://apt.insync.io/ubuntu focal non-free contrib"
+                        "deb http://apt.insync.io/ubuntu impish non-free contrib"
                     ]
                 }
             },
@@ -2347,7 +2315,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2375,7 +2343,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.microsoft.emmx",
             "url-ios": "https://apps.apple.com/us/app/microsoft-edge-web-browser/id1288723196",
             "arch": "amd64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2414,13 +2382,8 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.morlunk.mumbleclient.free",
             "url-ios": "http://itunes.apple.com/us/app/mumble/id443472808",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:mumble/release",
-                    "source-file": "mumble-ubuntu-release-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -2447,7 +2410,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.opera.browser",
             "url-ios": "https://itunes.apple.com/gb/app/opera-mini-web-browser/id363729560",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2478,7 +2441,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.nextcloud.client",
             "url-ios": "https://itunes.apple.com/gb/app/nextcloud/id1125420102",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -2506,7 +2469,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.owncloud.android",
             "url-ios": "https://itunes.apple.com/gb/app/owncloud/id543672169",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic",
+            "releases": "bionic,focal,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2539,7 +2502,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2568,7 +2531,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2598,7 +2561,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.skype.raider",
             "url-ios": "https://itunes.apple.com/gb/app/skype-for-iphone/id304878510",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2642,7 +2605,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2673,7 +2636,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.spideroak.android",
             "url-ios": "https://itunes.apple.com/gb/app/spideroak/id360584371",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2708,7 +2671,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.Slack&hl=en",
             "url-ios": "https://itunes.apple.com/gb/app/slack/id803453959?mt=12",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2742,7 +2705,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid",
             "url-ios": null,
             "arch": "i386,amd64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2782,7 +2745,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.telegram.messenger",
             "url-ios": "https://itunes.apple.com/gb/app/telegram-messenger/id686449807",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2814,7 +2777,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2847,7 +2810,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2875,7 +2838,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -2904,12 +2867,12 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
                 },
-                "xenial,bionic": {
+                "bionic": {
                     "method": "ppa",
                     "enable-ppa": "ppa:plushuang-tw/uget-stable",
                     "source-file": "plushuang-tw-ubuntu-uget-stable-CODENAME"
@@ -2934,7 +2897,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2965,7 +2928,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -2998,7 +2961,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.wire",
             "url-ios": "https://itunes.apple.com/gb/app/wire-private-messenger/id930944768",
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3030,15 +2993,10 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
-                },
-                "xenial": {
-                  "method": "ppa",
-                  "enable-ppa": "ppa:wireshark-dev/stable",
-                  "source-file": "wireshark-ubuntu-stable-CODENAME"
                 }
             },
             "working": true
@@ -3063,7 +3021,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3091,7 +3049,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3131,7 +3089,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3158,7 +3116,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3191,7 +3149,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3216,7 +3174,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -3248,7 +3206,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3283,7 +3241,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3314,7 +3272,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3343,7 +3301,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial",
+            "releases": "bionic,focal",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -3372,7 +3330,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3400,7 +3358,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3432,13 +3390,8 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:texworks/stable",
-                    "source-file": "texworks-ubuntu-stable-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -3468,7 +3421,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3496,7 +3449,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial",
+            "releases": "impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3525,7 +3478,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3556,7 +3509,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3590,7 +3543,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3622,7 +3575,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3650,7 +3603,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3680,7 +3633,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3708,7 +3661,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,i386",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3739,7 +3692,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,i386",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3775,7 +3728,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3808,7 +3761,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic",
+            "releases": "bionic,impish",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3841,7 +3794,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -3877,7 +3830,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3909,7 +3862,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,disco",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -3946,7 +3899,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -3976,7 +3929,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4002,7 +3955,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -4033,7 +3986,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4060,7 +4013,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4087,13 +4040,8 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:me-davidsansome/clementine",
-                    "source-file": "me-davidsansome-ubuntu-clementine-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -4125,13 +4073,8 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:mscore-ubuntu/mscore-stable",
-                    "source-file": "mscore-ubuntu-mscore-stable-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -4163,7 +4106,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -4193,7 +4136,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4250,7 +4193,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4280,7 +4223,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4309,7 +4252,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.google.android.music",
             "url-ios": "https://itunes.apple.com/gb/app/google-play-music/id691797987",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -4342,7 +4285,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4374,7 +4317,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4405,15 +4348,10 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.xbmc.kodi",
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
-                },
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:team-xbmc/ppa",
-                    "source-file": "team-xbmc-ubuntu-ppa-CODENAME"
                 }
             },
             "working": true
@@ -4439,7 +4377,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,arm64,armhf",
-            "releases": "focal,groovy,hirsute,impish,jammy",
+            "releases": "focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4477,7 +4415,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -4512,12 +4450,10 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:obsproject/obs-studio",
-                    "source-file": "obsproject-ubuntu-obs-studio-CODENAME"
+                    "method": "skip"
                 }
             },
             "working": true
@@ -4544,7 +4480,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.pandora.android",
             "url-ios": "https://itunes.apple.com/en/app/pandora-radio/id284035177",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4573,7 +4509,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4603,9 +4539,9 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial,bionic": {
+                "bionic": {
                     "method": "ppa",
                     "enable-ppa": "ppa:peek-developers/stable",
                     "source-file": "peek-developers-ubuntu-stable-CODENAME"
@@ -4636,7 +4572,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4667,7 +4603,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4696,13 +4632,8 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:maarten-baert/simplescreenrecorder",
-                    "source-file": "maarten-baert-ubuntu-simplescreenrecorder-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -4729,7 +4660,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4755,7 +4686,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.spotify.music",
             "url-ios": "https://itunes.apple.com/gb/app/spotify-music/id324684580",
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -4787,7 +4718,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.videolan.vlc",
             "url-ios": "https://itunes.apple.com/gb/app/vlc-for-mobile/id650377962",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4814,7 +4745,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,disco",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -4850,7 +4781,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4881,7 +4812,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4908,7 +4839,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,arm64,armhf",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4935,7 +4866,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4963,7 +4894,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -4990,7 +4921,7 @@
             "url-android": "https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp",
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5018,7 +4949,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5045,7 +4976,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5075,7 +5006,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,disco",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                   "method": "skip"
@@ -5105,7 +5036,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5136,13 +5067,8 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:cesar-crea-si/eviacam",
-                    "source-file": "cesar-crea-si-ubuntu-eviacam-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -5169,7 +5095,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5198,7 +5124,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5230,7 +5156,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64,armhf",
-            "releases": "xenial,bionic,disco,focal,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "manual",
@@ -5263,7 +5189,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5293,13 +5219,8 @@
             "url-android": "https://play.google.com/store/apps/details?id=com.morlunk.mumbleclient.free",
             "url-ios": "http://itunes.apple.com/us/app/mumble/id443472808",
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
-                "xenial": {
-                    "method": "ppa",
-                    "enable-ppa": "ppa:mumble/release",
-                    "source-file": "mumble-ubuntu-release-CODENAME"
-                },
                 "all": {
                     "method": "skip"
                 }
@@ -5328,7 +5249,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5356,7 +5277,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5383,7 +5304,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5414,7 +5335,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5441,7 +5362,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5468,7 +5389,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5491,7 +5412,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5516,7 +5437,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5539,7 +5460,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5562,7 +5483,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5585,7 +5506,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5608,7 +5529,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5631,7 +5552,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5654,7 +5575,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5677,7 +5598,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5700,7 +5621,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5723,7 +5644,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5746,7 +5667,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5773,7 +5694,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan",
+            "releases": "bionic",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5827,7 +5748,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "amd64",
-            "releases": "groovy",
+            "releases": "impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5850,7 +5771,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5873,7 +5794,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "skip"
@@ -5896,7 +5817,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5921,7 +5842,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64",
-            "releases": "xenial,bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5946,7 +5867,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5971,7 +5892,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -5996,7 +5917,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6021,7 +5942,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6046,7 +5967,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6071,7 +5992,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6096,7 +6017,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6121,7 +6042,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",
@@ -6146,7 +6067,7 @@
             "url-android": null,
             "url-ios": null,
             "arch": "i386,amd64,armhf,arm64",
-            "releases": "bionic,eoan,focal,groovy,hirsute,impish,jammy",
+            "releases": "bionic,focal,impish,jammy",
             "pre-install": {
                 "all": {
                     "method": "ppa",

--- a/tests/ping-ext-sources.py
+++ b/tests/ping-ext-sources.py
@@ -19,13 +19,18 @@ import requests
 test.start()
 
 # Default placeholders for manual entries.
-default_codename = 'xenial'
-default_version  = '16.04'
+default_codename = 'bionic'
+default_version  = '18.04'
 
 # Skipped Checks (Program IDs)
 skipped_ids = [
                'google-chrome',     # Purposefully 404's
-               'emby',              # No 16.04 source
+               'google-earth',      # Purposefully 404's
+               'etcher',            # Purposefully 404's
+               'sublime-text',      # Purposefully 404's
+               'sublime-merge',     # Purposefully 404's
+               'atom',              # Purposefully 404's
+               'slack'              # Purposefully 404's
               ]
 
 # Dictonary of URLs. Unique to prevent duplicates.

--- a/tests/validate-apps.py
+++ b/tests/validate-apps.py
@@ -14,7 +14,7 @@ import json
 ###############################################
 test.start()
 
-valid_distro_codenames = ['trusty', 'xenial', 'artful', 'bionic', 'disco', 'eoan', 'focal', 'groovy', 'hirsute', 'impish']
+valid_distro_codenames = ['trusty', 'xenial', 'artful', 'bionic', 'disco', 'eoan', 'focal', 'groovy', 'hirsute', 'impish', 'jammy']
 valid_arch = ['i386', 'amd64', 'armhf', 'arm64']
 
 # Load Applications JSON


### PR DESCRIPTION
I did the following:
1. Removed all EOL and ESM releases, so I keep *bionic*, *focal*, *impish* and upcoming *jammy*
1. Updated set of packages for GCompris
1. Updated existing apps to reflect their support in official repositories
1. Allowed LibreOffice to upgrade from its PPA on *bionic* and *focal*
1. Updated tests/ping-ext-sources.py to use *bionic* as default release
1. Updated tests/validate-apps.py to inform it about *jammy* release

Tested the changes as follows:
1. Ran `./perform-tests.sh --quick` and `./perform-tests.sh --extended` locally
1. Examined index status by `tools/app-index-debugger.py`
1. Ran x11docker x86_64/amd64 containers with *bionic*, *focal*, *impish* and *jammy*
