### PR TITLE
Colours: Open Appearance directly for >=22.04

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -80,6 +80,7 @@
           </button>
           <button style="display:none" id="browser-selection" class="btn btn-block btn-default" onclick="exitMenu('browser-selection.html')"><span class="fa fa-2x fa-globe fa-va"></span>&nbsp; &zwnj;Browser Selection&zwnj;</button>
           <button style="display:none" id="colour-selection" class="btn btn-block btn-default" onclick="exitMenu('colour-selection.html')"><span class="fa fa-2x fa-eye fa-va"></span>&nbsp; &zwnj;Color Selection&zwnj;</button>
+          <button style="display:none" id="change-theme" class="btn btn-block btn-default" onclick="cmd('theme')"><span class="fa fa-2x fa-eye fa-va"></span>&nbsp; &zwnj;Color Selection&zwnj;</button>
           <button style="display:none" id="panel-selection" class="btn btn-block btn-success" onclick="exitMenu('panel-selection.html')"><span class="fa fa-2x fa-mouse-pointer fa-va"></span>&nbsp; &zwnj;Desktop Layout&zwnj;</button>
         </div>
       </div>

--- a/ubuntu-mate-welcome
+++ b/ubuntu-mate-welcome
@@ -1092,8 +1092,12 @@ class AppView(WebKit2.WebView):
                 app.update_page('#autostart', 'addClass', 'fa-square')
 
             # Enable custom coloured themes if supported in this version
-            if should_offer_custom_themes() == True:
+            if should_offer_custom_themes():
                 btns.append('colour-selection')
+
+            # Show button to change theme
+            if float(systemstate.os_version) >= 22.04:
+                btns.append('change-theme')
 
             # Disable features that are unavailable to guests.
             if systemstate.session_type == 'guest':
@@ -1502,6 +1506,8 @@ class AppView(WebKit2.WebView):
                 subprocess.Popen(['gparted-pkexec'])
         elif cmd == 'sysmonitor':
             subprocess.Popen(['mate-system-monitor'])
+        elif cmd == 'theme':
+            subprocess.Popen(['mate-appearance-properties', '--show-page', 'theme'])
         elif cmd.startswith('run?'):
             subprocess.Popen([cmd[4:]])
         elif cmd.startswith('link?'):
@@ -3988,9 +3994,11 @@ def should_offer_to_change_panels():
 
 def should_offer_custom_themes():
     """
-    Determine if user is running Ubuntu [MATE] 18.04 or later.
+    Colour themes were provided by the community project "ubuntu-mate-colours".
+    These were introduced in 18.04 for Ambiant-MATE; 21.04 for Yaru-MATE and
+    then removed starting in 22.04, as these are bundled with the distro itself.
     """
-    if float(systemstate.os_version) >= 18.04 and which("gsettings") != None:
+    if float(systemstate.os_version) >= 18.04 and float(systemstate.os_version) <= 21.10 and which("gsettings") != None:
         return True
     else:
         return False


### PR DESCRIPTION
Ubuntu MATE 22.04 now gets its colours via the Yaru project, but the old screen remains for backwards compatibility.

For context:

* https://discord.com/channels/712850672223125565/810848412815720448/955861079962058842
* https://discord.com/channels/712850672223125565/775655177188933652/951552821642268752