### PR TITLE
Change OS X->macOS in introduction

### DIFF
--- a/data/introduction.html
+++ b/data/introduction.html
@@ -55,7 +55,7 @@
             &nbsp;<button class="link" onclick="cmd('link?http://www.microsoft.com')">
             <span class="fa fa-windows"></span> &zwnj;Microsoft's Windows&zwnj;</button>,
             &nbsp;<button class="link" onclick="cmd('link?http://www.apple.com')">
-            <span class="fa fa-apple"> </span> &zwnj;Apple's OS X&zwnj;</button> &zwnj;and&zwnj;
+            <span class="fa fa-apple"> </span> &zwnj;Apple's macOS&zwnj;</button> &zwnj;and&zwnj;
             &nbsp;<button class="link" onclick="cmd('link?http://www.google.com/chrome')">
             <span class="fa fa-chrome"></span> &zwnj;Google's Chrome OS&zwnj;</button>.
 


### PR DESCRIPTION
Update to new official name of the OS.

Having said that, I notice that a lot of the text is also on https://guide.ubuntu-mate.org which already says "macOS" and has other improvements, so maybe there needs to be a proper comparison and import of text from there.